### PR TITLE
Delegates CORS control to another ENV variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ JWT_KEY=secretKey
 RUN_MIGRATIONS=true
 NODE_ENV=development
 PORT=3000
+ENABLE_CORS=true
 
 PF_API=https://app.peopleforce.io/api/public/v1
 PF_API_KEY=key

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import { candidatesCron } from './cron/candidates';
 import { employeeCron } from './cron/employee';
 
 const corsOrigins =
-  process.env.NODE_ENV === 'production'
+  process.env.ENABLE_CORS === 'true'
     ? [process.env.FE_ORIGIN]
     : [
         /\.web\.app$/,


### PR DESCRIPTION
There is no need to run BE locally if only the front end needs to be changed. This allows CORS to be disabled in the development environment.